### PR TITLE
Added support for ShellyPlus1PM

### DIFF
--- a/src/HeatKeeper.Reporter.Sdk.Tests/MapperTests.cs
+++ b/src/HeatKeeper.Reporter.Sdk.Tests/MapperTests.cs
@@ -149,5 +149,20 @@ namespace HeatKeeper.Reporter.Sdk.Tests
             measurements.Should().Contain(m => m.Value == 136.5 && m.MeasurementType == MeasurementType.ActivePowerImport && m.SensorId == "shellies/plug-s/hytta/spisestue");
             measurements.Should().Contain(m => m.Value == 208808.371 && m.MeasurementType == MeasurementType.CumulativePowerImport && m.SensorId == "shellies/plug-s/hytta/spisestue");
         }
+
+        [Fact]
+        public async Task ShouldMapShellyPlus1PM()
+        {
+            var sensorData = new ResourceBuilder().AddAssembly(typeof(MapperTests).Assembly).Build<ISensorData>();
+            MqttApplicationMessage message = new()
+            {
+                Payload = Encoding.UTF8.GetBytes(sensorData.ShellyPlus1PM_mqtt),
+                Topic = "shelly/plus-1PM/aabbccddee/status/switch:0"
+            };
+
+            var measurements = await MqttSensors.ShellyPlus1PM().HandleMessage(message);
+            measurements.Should().Contain(m => m.Value == 983.8 && m.MeasurementType == MeasurementType.ActivePowerImport && m.SensorId == "shelly/plus-1PM/aabbccddee");
+            measurements.Should().Contain(m => m.Value == 81.664 && m.MeasurementType == MeasurementType.CumulativePowerImport && m.SensorId == "shelly/plus-1PM/aabbccddee");
+        }
     }
 }

--- a/src/HeatKeeper.Reporter.Sdk.Tests/TestData.cs
+++ b/src/HeatKeeper.Reporter.Sdk.Tests/TestData.cs
@@ -31,5 +31,7 @@ namespace HeatKeeper.Reporter.Sdk.Tests
         string ShellyPlugS_Power { get; }
 
         string ShellyPlugPlusS { get; }
+
+        string ShellyPlus1PM_mqtt { get; }
     }
 }

--- a/src/HeatKeeper.Reporter.Sdk/MqttReporter.cs
+++ b/src/HeatKeeper.Reporter.Sdk/MqttReporter.cs
@@ -188,6 +188,31 @@ public static partial class MqttSensors
         });
     }
 
+    public static MqttSensor ShellyPlus1PM()
+    {
+        return new MqttSensor("shelly/plus-1PM/#", async applicationMessage =>
+        {
+            var topic = applicationMessage.Topic;
+            var payload = applicationMessage.ConvertPayloadToString();
+            var timestamp = DateTime.UtcNow;
+
+            if (topic.EndsWith("/status/switch:0", StringComparison.OrdinalIgnoreCase))
+            {
+                var sensorId = topic[..^"/status/switch:0".Length];
+                var document = JsonDocument.Parse(payload);
+                var power = document.RootElement.GetProperty("apower").GetDouble();
+                var energyWh = document.RootElement.GetProperty("aenergy").GetProperty("total").GetDouble();
+                return
+                [
+                    new Measurement(sensorId, MeasurementType.ActivePowerImport, RetentionPolicy.Hour, power, timestamp),
+                    new Measurement(sensorId, MeasurementType.CumulativePowerImport, RetentionPolicy.Hour, energyWh, timestamp)
+                ];
+            }
+
+            return Array.Empty<Measurement>();
+        });
+    }
+
     public static MqttSensor ShellyPlugS()
     {
         return new MqttSensor("shellies/plug-s/#", async applicationMessage =>


### PR DESCRIPTION
## Summary
- Added `MqttSensors.ShellyPlus1PM()` subscribing to `shelly/plus-1PM/#`
- Parses `status/switch:0` payload, extracting `ActivePowerImport` and `CumulativePowerImport`
- Added test data interface property and unit test

## Test plan
- [ ] All existing tests pass
- [ ] `ShouldMapShellyPlus1PM` test verifies correct parsing of `apower` and `aenergy.total`

🤖 Generated with [Claude Code](https://claude.com/claude-code)